### PR TITLE
Optional nginx status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ General Configuration:
 Nginx Configuration:
 * `API_KEY_HEADER`: This is the header name used by nginx to identify the API Key used _(Default: `X-ROUTING-API-KEY`)_
 * `DEFAULT_LOCATION_RETURN`: Configures nginx to return a status code of proxy to a URI if a request does not match any configured paths in a known host. Can be either a HTTP status code or URI that nginx uses with proxy_pass. _(Default: `404`)_
-* `NGINX_ENABLE_STATUS_ENDPOINT`: Enables a /dispatcher/status endpoint on the default server. (Default: `false`)
 * `NGINX_ENABLE_HEALTH_CHECKS`: Enables nginx upstream health checks. (Default: `false`)
 * `NGINX_MAX_CLIENT_BODY_SIZE`: Configures the max client request body size of nginx. _(Default: `0`, Disables checking of client request body size.)_
+* `NGINX_STATUS_PATH`: Change the nginx status path that returns 200 on the default server. (Default: `/dispatcher/status`)
 * `PORT`: This is the port that nginx will listen on _(Default: `80`)_
 
 # Security

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ General Configuration:
 Nginx Configuration:
 * `API_KEY_HEADER`: This is the header name used by nginx to identify the API Key used _(Default: `X-ROUTING-API-KEY`)_
 * `DEFAULT_LOCATION_RETURN`: Configures nginx to return a status code of proxy to a URI if a request does not match any configured paths in a known host. Can be either a HTTP status code or URI that nginx uses with proxy_pass. _(Default: `404`)_
+* `NGINX_ENABLE_STATUS_ENDPOINT`: Enables a /dispatcher/status endpoint on the default server. (Default: `false`)
 * `NGINX_ENABLE_HEALTH_CHECKS`: Enables nginx upstream health checks. (Default: `false`)
 * `NGINX_MAX_CLIENT_BODY_SIZE`: Configures the max client request body size of nginx. _(Default: `0`, Disables checking of client request body size.)_
 * `PORT`: This is the port that nginx will listen on _(Default: `80`)_

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -71,7 +71,14 @@ events {
   # Default server that will just close the connection as if there was no server available
   server {
     listen {{.Config.Nginx.Port}} default_server;
-    return 444;
+    {{if .Config.Nginx.EnableStatusEndpoint}}
+    location /dispatcher/status {
+      return 200;
+    }
+    {{- end}}
+    location / {
+      return 444;
+    }
   }
 {{- end}}
 

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -71,11 +71,11 @@ events {
   # Default server that will just close the connection as if there was no server available
   server {
     listen {{.Config.Nginx.Port}} default_server;
-    {{if .Config.Nginx.EnableStatusEndpoint}}
-    location /dispatcher/status {
+
+    location = {{.Config.Nginx.StatusPath}} {
       return 200;
     }
-    {{- end}}
+
     location / {
       return 444;
     }

--- a/nginx/config_test.go
+++ b/nginx/config_test.go
@@ -58,19 +58,19 @@ func TestPartialDefaultServer(t *testing.T) {
 		t.Fatalf("Expected default server to only return 444;")
 	}
 
-	if strings.Count(doc.String(), "location /dispatcher/status {") != 0 {
-		t.Fatalf("Expected default to not have status location;")
+	if strings.Count(doc.String(), "location = /dispatcher/status {") != 1 {
+		t.Fatalf("Expected default status path")
 	}
 
-	// Enable status endpoint
-	tmplData.Config.Nginx.EnableStatusEndpoint = true
+	// Update Status Path
+	tmplData.Config.Nginx.StatusPath = "/some/other/status"
 
 	if err := nginxTemplate.ExecuteTemplate(&doc, "default-server", tmplData); err != nil {
 		t.Fatalf("Failed to write template %v", err)
 	}
 
-	if strings.Count(doc.String(), "location /dispatcher/status {") != 1 {
-		t.Fatalf("Expected default to have status location;")
+	if strings.Count(doc.String(), "location = /some/other/status {") != 1 {
+		t.Fatalf("Expected default server to have updated status path;")
 	}
 
 }

--- a/nginx/config_test.go
+++ b/nginx/config_test.go
@@ -57,6 +57,22 @@ func TestPartialDefaultServer(t *testing.T) {
 	if idx := strings.Index(doc.String(), "return 444;"); idx < 0 {
 		t.Fatalf("Expected default server to only return 444;")
 	}
+
+	if strings.Count(doc.String(), "location /dispatcher/status {") != 0 {
+		t.Fatalf("Expected default to not have status location;")
+	}
+
+	// Enable status endpoint
+	tmplData.Config.Nginx.EnableStatusEndpoint = true
+
+	if err := nginxTemplate.ExecuteTemplate(&doc, "default-server", tmplData); err != nil {
+		t.Fatalf("Failed to write template %v", err)
+	}
+
+	if strings.Count(doc.String(), "location /dispatcher/status {") != 1 {
+		t.Fatalf("Expected default to have status location;")
+	}
+
 }
 
 func TestPartialBaseConfig(t *testing.T) {
@@ -430,7 +446,8 @@ func TestGetConfCheckLocationNoDefaultLocation(t *testing.T) {
 		t.Fatalf("Expected location /users in config")
 	}
 
-	if strings.Count(doc, "location / {") != 1 {
+	// 2 location / 1 for default server and 1 for this location
+	if strings.Count(doc, "location / {") != 2 {
 		t.Fatalf("Expected location / in config")
 	}
 

--- a/router/config.go
+++ b/router/config.go
@@ -60,6 +60,8 @@ type NginxConfig struct {
 	APIKeyHeader string
 	// Enable or disable nginx health checks for each pod
 	EnableHealthChecks bool
+	// Enable /status endpoint on default server.
+	EnableStatusEndpoint bool
 	// Max client request body size. nginx config: client_max_body_size. eg 10m
 	MaxClientBodySize string
 	// The port that nginx will listen on
@@ -124,6 +126,8 @@ func ConfigFromEnv() (*Config, error) {
 	addConfig("Nginx.APIKeyHeader", "API_KEY_HEADER", "X-ROUTING-API-KEY")
 	// Enable or disable nginx health checks using custom upstream check module. Default: disabled
 	addConfig("Nginx.EnableHealthChecks", "NGINX_ENABLE_HEALTH_CHECKS", false)
+	// Enable or disable /dispatcher/status endpoint on default nginx server.
+	addConfig("Nginx.EnableStatusEndpoint", "NGINX_ENABLE_STATUS_ENDPOINT", false)
 	// Nginx max client request size. Default 0, unlimited
 	addConfig("Nginx.MaxClientBodySize", "NGINX_MAX_CLIENT_BODY_SIZE", "0")
 	// The port that nginx will listen on

--- a/router/config.go
+++ b/router/config.go
@@ -24,6 +24,8 @@ const (
 	ErrMsgTmplInvalidServerReturnHTTPStatusCode = "%d is an invalid status code 100-999 for default server return"
 	// ErrMsgTmplInvalidServerReturnURL is the error message for an invalid url used for default server
 	ErrMsgTmplInvalidServerReturnURL = "%s is an invalid url for default server return %v"
+	//ErrMsgTmplInvalidPath is the error message for an invalid path
+	ErrMsgTmplInvalidPath = "%s is an invalid path"
 )
 
 /*
@@ -60,8 +62,8 @@ type NginxConfig struct {
 	APIKeyHeader string
 	// Enable or disable nginx health checks for each pod
 	EnableHealthChecks bool
-	// Enable /status endpoint on default server.
-	EnableStatusEndpoint bool
+	// Status path for nginx status endpoint on default server.
+	StatusPath string
 	// Max client request body size. nginx config: client_max_body_size. eg 10m
 	MaxClientBodySize string
 	// The port that nginx will listen on
@@ -127,7 +129,7 @@ func ConfigFromEnv() (*Config, error) {
 	// Enable or disable nginx health checks using custom upstream check module. Default: disabled
 	addConfig("Nginx.EnableHealthChecks", "NGINX_ENABLE_HEALTH_CHECKS", false)
 	// Enable or disable /dispatcher/status endpoint on default nginx server.
-	addConfig("Nginx.EnableStatusEndpoint", "NGINX_ENABLE_STATUS_ENDPOINT", false)
+	addConfig("Nginx.StatusPath", "NGINX_STATUS_PATH", "/dispatcher/status")
 	// Nginx max client request size. Default 0, unlimited
 	addConfig("Nginx.MaxClientBodySize", "NGINX_MAX_CLIENT_BODY_SIZE", "0")
 	// The port that nginx will listen on
@@ -183,6 +185,11 @@ func ConfigFromEnv() (*Config, error) {
 		if code < 100 || code > 999 {
 			return nil, fmt.Errorf(ErrMsgTmplInvalidServerReturnHTTPStatusCode, code)
 		}
+	}
+
+	// Validate nginx status path
+	if !validatePath(config.Nginx.StatusPath) {
+		return nil, fmt.Errorf(ErrMsgTmplInvalidPath, config.Nginx.StatusPath)
 	}
 
 	return &config, nil

--- a/router/config_test.go
+++ b/router/config_test.go
@@ -81,3 +81,15 @@ func TestConfigFromEnvInvailidDefaultServerReturnCode(t *testing.T) {
 		t.Fatal("Error should not nil")
 	}
 }
+
+/*
+Test for ConfigFromEnv should throw error on invalid default server return status code
+*/
+func TestConfigFromEnvInvailidStatusPath(t *testing.T) {
+	resetEnv()
+	os.Setenv("NGINX_STATUS_PATH", "/<>asd")
+	_, err := ConfigFromEnv()
+	if err == nil {
+		t.Fatal("Error should not nil")
+	}
+}


### PR DESCRIPTION
Supports optionally allowing a `/dispatcher/status` endpoint on the default server with `NGINX_ENABLE_STATUS_ENDPOINT=true`.