### PR TITLE
Support pod/routes weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ The Namespaces marked for routing are then analyzed to identify wiring informati
 
 Annotations:
 * `github.com/30x.dispatcher.hosts`: Stores host-level configuration for each host associated with Namespace. JSON document, whose
-keys are the actual hostnames and whose values are the host-specific configuration.
-Host-specific configuration currently only supports enabling SSL.
+keys are the actual hostnames and whose values are the host-specific configuration. Host-specific configuration currently only supports enabling SSL.
 
 ```
 annotations:
@@ -60,6 +59,7 @@ Annotations:
   * `basePath`: This is the request path the router uses to identify traffic for a specific application.
   * `containerPort`: This is the port of the container running the application logic handling traffic for the associated path.
   * `targetPath (optional):` This is the path that the target application is written to handle traffic for (If this configuration is omitted, the target request path is untouched.  If this configuration is provided, it is a URI rewrite of the path where the router path is replaced by the target path. For example, if your router path was /foo and your target path was /bar, a request for /foo/1 would be sent to the target as /bar/1)
+  * `weight (optional):` This is a nginx upstream weight associated with path. Can be an integer > 0. See: http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server
 
 Labels:
 * `github.com/30x.dispatcher.app.name`: String representing the name of the application.

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -29,7 +29,7 @@ http {
     keepalive 1024;
     {{range $server := $upstream.Servers}}
     # Pod {{$server.Pod.Name}} (namespace: {{$server.Pod.Namespace}})
-    server {{$server.Target}};
+    server {{$server.Target}}{{if $server.Weight}} weight={{$server.Weight}}{{end}};
     {{if and $.Config.Nginx.EnableHealthChecks $upstream.HealthCheck }}
     {{template "upstream-healthcheck" $upstream.HealthCheck}}
     {{- end}}
@@ -209,6 +209,7 @@ type upstreamT struct {
 
 type serverT struct {
 	Pod    *router.PodWithRoutes
+	Weight *uint
 	Target string
 }
 
@@ -445,6 +446,7 @@ func GetConf(config *router.Config, cache *router.Cache) string {
 					upstream.Servers = append(upstream.Servers, &serverT{
 						Pod:    pod,
 						Target: target,
+						Weight: route.Outgoing.Weight,
 					})
 
 					// Sort to make finding your pods in an upstream easier
@@ -465,6 +467,7 @@ func GetConf(config *router.Config, cache *router.Cache) string {
 							&serverT{
 								Pod:    pod,
 								Target: target,
+								Weight: route.Outgoing.Weight,
 							},
 						},
 					}

--- a/router/pods_test.go
+++ b/router/pods_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func path(basePath, port, targetPath string) pathAnnotation {
-	p := pathAnnotation{basePath, port, nil}
+	p := pathAnnotation{basePath, port, nil, nil}
 	if targetPath != "" {
 		p.TargetPath = &targetPath
 	}
@@ -821,5 +821,31 @@ func TestValidatePath(t *testing.T) {
 		if validatePath(path) == false {
 			t.Fatalf("Expected (%s) to pass.", path)
 		}
+	}
+}
+
+func TestPodWeight(t *testing.T) {
+	w := uint(5)
+	p := pathAnnotation{
+		BasePath:      "/node",
+		ContainerPort: "3000",
+		Weight:        &w,
+	}
+	pod1 := genPod("some-pod", genRoutes(p), "1.2.3.4", api.PodRunning, []string{"3000"})
+
+	if *pod1.Routes[0].Outgoing.Weight != 5 {
+		t.Fatalf("Expected pods route[0].Outgoing.Weight to be %d was %d", 5, *pod1.Routes[0].Outgoing.Weight)
+	}
+
+	w = uint(0)
+	p = pathAnnotation{
+		BasePath:      "/node",
+		ContainerPort: "3000",
+		Weight:        &w,
+	}
+	pod2 := genPod("some-pod", genRoutes(p), "1.2.3.4", api.PodRunning, []string{"3000"})
+
+	if len(pod2.Routes) != 0 {
+		t.Fatalf("Expected pods routes to be empty with invalid weight")
 	}
 }


### PR DESCRIPTION
Implements #21 

A pod annotation route can now optionally have a `weight` parameter that is passed to the nginx config in the upstream server. If the weight is invalid the route is ignored and a warning message it outputted. Weights can be an integer > 0.

Eg.

```
github.com/30x.dispatcher.paths: '[{"basePath": "/nodejs", "containerPort": "3000", "weight": 2}]'
```

Would generate a upstream with a server like:

```
server 172.17.0.10:3000 weight=2;
```

The default without a weight does not specify a nginx weight and allows nginx to default to `1`.

```
github.com/30x.dispatcher.paths: '[{"basePath": "/nodejs", "containerPort": "3000", "weight": 2}]'
```

```
server 172.17.0.10:3000;
```


