### PR TITLE
Set host header in nginx config in location{}

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -56,6 +56,9 @@ http {
       proxy_http_version 1.1;
       proxy_set_header Connection "";
 
+      # Set Host Header, if not nginx will use upsteam's name 
+      proxy_set_header Host $http_host;
+
       #Upstream {{$location.Upstream}}
       proxy_pass http://{{$location.Upstream}}{{if $location.TargetPath}}{{$location.TargetPath}}{{end}};
     }
@@ -172,7 +175,6 @@ events {
 
   # Pass through the appropriate headers
   proxy_set_header Connection $p_connection;
-  proxy_set_header Host $http_host;
   proxy_set_header Upgrade $http_upgrade;
 {{- end}}
 `


### PR DESCRIPTION
When setting the host header with `proxy_set_header Host $http_host;` we were setting it at the http{} level in the nginx config. @jlin21 noticed the upstream application was receiving the host as the upstreams name in nginx.

The only i found for the host header to pass correctly was setting it in the location{} section in the nginx template.